### PR TITLE
Code Review: Only use LTO in some variants (#7818)

### DIFF
--- a/Extras/Scripts/elegantchaos/hipchat.py
+++ b/Extras/Scripts/elegantchaos/hipchat.py
@@ -30,12 +30,13 @@ def hipchat_room_request(command, room, token, data):
     room_command = "room/" + room + "/" + command
     return hipchat_request(room_command, token, data)
 
-def hipchat_message_request(message, color, room, token, mode):
-    data = urllib.urlencode({ "message" : message, "color" : color, "message_format" : mode})
+def hipchat_message_request(message, color, room, token, mode, notify):
+    info = { "message" : message, "color" : color, "message_format" : mode, "notify" : notify }
+    data = urllib.urlencode(info)
     return hipchat_room_request("notification", room, token, data)
 
-def hipchat_message(message, colour, room, token, mode):
-    request = hipchat_message_request(message, colour, room, token, mode)
+def hipchat_message(message, colour, room, token, mode, notify = "true"):
+    request = hipchat_message_request(message, colour, room, token, mode, notify)
     response = urllib2.urlopen(request)
     return response.read()
 


### PR DESCRIPTION
Code review for Only use LTO in some variants (#7818):

> The bug in #7631 (which turned to be caused by LTO) shows the value of testing with LTO enabled if we're going to release using LTO, so that we test the same code that we actually release.
> 
> However, LTO does slow down compilation, and it probably isn't necessary to use it for every single run of the tests.
> 
> Currently LTO is on for any release build.
> 
> What I propose doing instead is turning it on only for release with the following variants: `SketchNonAppStore`, `SketchBeta`, `SketchPrivateBeta`.
> 
> This will mean that the normal release and feature tests (which are built with the Xcode variant) don't use LTO (and hopefully will turn around a bit faster, as a result).
> 
> The new `boho stage` command, however, will use one of the variants listed above when it runs its unit tests - so as long as we use that command to build and stage things for release, we can guarantee that we've checked that all the tests run correctly with LTO enabled.

Connect to BohemianCoding/Sketch#7818.
