### PR TITLE
Code Review: Make a log channel for deprecated methods, and capture it when running scripts (#6208)

### DIFF
--- a/Source/Generic/ECLogChannel.m
+++ b/Source/Generic/ECLogChannel.m
@@ -59,7 +59,9 @@ static NSString* const kSuffixToStrip = @"Channel";
 	{
 		self.enabled = YES;
 		ECMakeContext();
-		logToChannel(self, &ecLogContext, @"enabled channel");
+		if (self.context & ECLogContextMeta) {
+			logToChannel(self, &ecLogContext, @"enabled channel");
+		}
 	}
 }
 
@@ -72,7 +74,9 @@ static NSString* const kSuffixToStrip = @"Channel";
 	if (self.enabled)
 	{
 		ECMakeContext();
-		logToChannel(self, &ecLogContext, @"disabled channel");
+		if (self.context & ECLogContextMeta) {
+			logToChannel(self, &ecLogContext, @"disabled channel");
+		}
 		self.enabled = NO;
 	}
 }

--- a/Source/Generic/ECLogContext.h
+++ b/Source/Generic/ECLogContext.h
@@ -27,6 +27,7 @@ typedef NS_OPTIONS(NSUInteger, ECLogContextFlags)
 	ECLogContextFunction = 0x0004,
 	ECLogContextMessage = 0x0008,
 	ECLogContextName = 0x0010,
+	ECLogContextMeta = 0x0020,
 
 	ECLogContextFullPath = 0x1000,
 	ECLogContextDefault = 0x8000

--- a/Source/Generic/ECLogHandler.m
+++ b/Source/Generic/ECLogHandler.m
@@ -82,7 +82,9 @@
 - (void)wasEnabledForChannel:(ECLogChannel*)channel
 {
 	ECMakeContext();
-	logToChannel(channel, &ecLogContext, @"Enabled handler %@", self.name);
+	if (channel.context & ECLogContextMeta) {
+		logToChannel(channel, &ecLogContext, @"Enabled handler %@", self.name);
+	}
 }
 
 // --------------------------------------------------------------------------
@@ -93,7 +95,9 @@
 - (void)wasDisabledForChannel:(ECLogChannel*)channel
 {
 	ECMakeContext();
-	logToChannel(channel, &ecLogContext, @"Disabled handler %@", self.name);
+	if (channel.context & ECLogContextMeta) {
+		logToChannel(channel, &ecLogContext, @"Disabled handler %@", self.name);
+	}
 }
 
 @end

--- a/Source/Generic/ECLogManager.m
+++ b/Source/Generic/ECLogManager.m
@@ -80,7 +80,8 @@ const ContextFlagInfo kContextFlagInfo[] = {
 	{ ECLogContextDate, @"Date" },
 	{ ECLogContextFunction, @"Function" },
 	{ ECLogContextMessage, @"Message" },
-	{ ECLogContextName, @"Name" }
+	{ ECLogContextName, @"Name" },
+	{ ECLogContextMeta, @"Meta" }
 };
 
 #define TEST_ERROR 0 // enable this for a deliberate compiler error (handy when testing build reporting scripts)
@@ -305,7 +306,7 @@ static ECLogManager* gSharedInstance = nil;
 
 	NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
 	self.channels = dictionary;
-	self.defaultContextFlags = ECLogContextName | ECLogContextMessage;
+	self.defaultContextFlags = ECLogContextName | ECLogContextMessage | ECLogContextMeta;
 
 	[self loadSettings];
 	[self registerHandlers];


### PR DESCRIPTION
Code review for Make a log channel for deprecated methods, and capture it when running scripts (#6208):

> The idea here is that we can log to the channel from any method that’s now deprecated in a script.
> 
> By default the channel will be disabled, but when running scripts we can enable it, and capture any output to it, so that we can log the deprecation warnings for script authors to see.
> 
> (see also #4066 for a discussion around this topic)

Connect to BohemianCoding/Sketch#6208.
