### PR TITLE
Code Review: Use virtualenv to isolate our tool dependencies better (#8071)

### DIFF
--- a/Extras/Scripts/elegantchaos/shell.py
+++ b/Extras/Scripts/elegantchaos/shell.py
@@ -14,11 +14,6 @@ import errors
 import getopt
 import re
 
-try:
-    from docopt import docopt
-except:
-    exit_with_message("This script requires docopt. You can install it with: pip install docopt.", errors.ERROR_REQUIRED_MODULE_MISSING)
-
 RE_XCODE_VERSION = re.compile('Xcode ([\d.]+).*')
 
 
@@ -234,3 +229,10 @@ def call_output_and_result(cmd):
         return (0, subprocess.check_output(cmd, stderr = subprocess.STDOUT))
     except subprocess.CalledProcessError as e:
         return (e.returncode, e.output)
+
+
+
+try:
+    from docopt import docopt
+except:
+    exit_with_message("This script requires docopt. You can install it with: pip install docopt.", errors.ERROR_REQUIRED_MODULE_MISSING)


### PR DESCRIPTION
Code review for Use virtualenv to isolate our tool dependencies better (#8071):

> Our tools require some python modules to be installed, and they might potentially clash with the system modules.
> 
> We can get round this by using the `virtualenv` python module to install local copies inside the Sketch directory.

Connect to BohemianCoding/Sketch#8071.
