### PR TITLE
Code Review: Scripting issues with Latest beta (#8453)

### DIFF
--- a/Source/Generic/ECLogManager.m
+++ b/Source/Generic/ECLogManager.m
@@ -310,6 +310,7 @@ static ECLogManager* gSharedInstance = nil;
 
 	[self loadSettings];
 	[self registerHandlers];
+	[self loadChannelSettings];
 
 	// The log manager is created on demand, the first time that a channel needs to register itself.
 	// This allows channels to be declared and used in the simplest possible way, and to work in code
@@ -508,8 +509,6 @@ static ECLogManager* gSharedInstance = nil;
 		self.settings[HandlersKey] = handlers;
 	}
 
-	[self loadChannelSettings];
-
 	// the showMenu property is read/set here in generic code, but it's up to the
 	// platform specific UI support to interpret it
 	BOOL forceMenu = [userSettings boolForKey:ForceDebugMenuKey];
@@ -688,6 +687,7 @@ static ECLogManager* gSharedInstance = nil;
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:LogManagerSettingsKey];
 	[self loadSettings];
 	[self registerHandlers];
+	[self loadChannelSettings];
 	[self resetAllChannels];
 	[self postUpdateNotification];
 }


### PR DESCRIPTION
Code review for Scripting issues with Latest beta (#8453):

> Turns out we couldn't release a beta today because we have two (that we know of) problems with scripting.
> ### Invision Craft crashes:
> 
> ```
> 24/03/2016 19:18:46.070 Toggle Craft (Sketch Plugin)[69706]: -[MSPluginCommand initWithScript:identifier:name:handler:shortcut:]: unrecognized selector sent to instance 0x7ffa068ce570
> ```
> 
> I guess we should keep the old method with a deprecation warning
> ### Framer is broken:
> 
> Framer is relying on reading output from the syslog to detect errors etc with their import. Previously we logged plugin stuff to the syslog with the plugin session prefix. Now we don't do anything apparently.
> Koen suggests that we could maybe better write a log file to some known location on disk, but if we could for now re-enable that log somehow that'd be good.
> 
> Ping @samdeane for comments and hopefully a simple fix and @hamishmcneill to keep him in the loop

Connect to BohemianCoding/Sketch#8453.
