### PR TITLE
Code Review: Fix "test reported a suite with nil" warning from Xcode when running tests (#10097)

### DIFF
--- a/Source/Generic/ECTestCase.m
+++ b/Source/Generic/ECTestCase.m
@@ -40,7 +40,7 @@
 	}
 	else
 	{
-		result = [XCTestSuite testSuiteWithName:@""];
+		result = [XCTestSuite testSuiteWithName:NSStringFromClass([self class])];
 	}
 
 	return result;


### PR DESCRIPTION
Code review for Fix "test reported a suite with nil" warning from Xcode when running tests (#10097):

> Xcode is spitting out this warning:
> 
> ![](https://s3.amazonaws.com/uploads.hipchat.com/191334/1363324/FeYkxEAaiwjGgKY/upload.png)

Connect to BohemianCoding/Sketch#10097.
