### PR TITLE
Code Review: make ECCommandLine tests a bit more synchronous (#10469)

### DIFF
--- a/Source/Generic/ECTestCase.h
+++ b/Source/Generic/ECTestCase.h
@@ -359,7 +359,7 @@ typedef NS_ENUM(NSUInteger, ECTestComparisonMode)
  Run a command line tool and return its output.
  */
 
-- (NSData*)runCommand:(NSString*)command arguments:(NSArray*)arguments status:(int*)status;
+- (NSData*)runCommand:(NSString*)command arguments:(NSArray*)arguments status:(int*)status error:(NSData* __autoreleasing *)error;
 
 /**
  Write an image as an output file.


### PR DESCRIPTION
Code review for make ECCommandLine tests a bit more synchronous (#10469):

> We have an occasional problem with output from the ECCommandLine unit tests messing up the output from the unit test reporting system, which causes our regexps to fail when scanning the test results.
> 
> This might be fixable by making the tests a bit more synchronous and ensuring that they wait properly for subprocesses to completely finish running.

Connect to BohemianCoding/Sketch#10469.
