### PR TITLE
Code Review: Make all rendering comparison tests work with artboards (#10473)

### DIFF
--- a/Source/Generic/ECTestCase.m
+++ b/Source/Generic/ECTestCase.m
@@ -695,8 +695,7 @@
 	[NSGraphicsContext setCurrentContext:ctx];
 
 	NSRect rect = NSMakeRect(0, 0, width, height);
-	NSRect fromRect = NSMakeRect(0, 0, bitmap.size.width, bitmap.size.height);
-	[bitmap drawInRect:rect fromRect:fromRect operation:NSCompositeCopy fraction:1.0 respectFlipped:NO hints:nil];
+	[bitmap drawInRect:rect fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0 respectFlipped:NO hints:nil];
 	[ctx flushGraphics];
 	[NSGraphicsContext restoreGraphicsState];
 

--- a/Source/Generic/ECTestCase.m
+++ b/Source/Generic/ECTestCase.m
@@ -672,8 +672,8 @@
 
 - (NSBitmapImageRep*)bitmapAs32BitRGBA:(NSBitmapImageRep*)bitmap
 {
-	NSInteger width = (NSInteger)[bitmap size].width;
-	NSInteger height = (NSInteger)[bitmap size].height;
+	NSInteger width = bitmap.pixelsWide;
+	NSInteger height = bitmap.pixelsHigh;
 
 	if (width < 1 || height < 1)
 		return nil;
@@ -695,7 +695,8 @@
 	[NSGraphicsContext setCurrentContext:ctx];
 
 	NSRect rect = NSMakeRect(0, 0, width, height);
-	[bitmap drawInRect:rect fromRect:rect operation:NSCompositeCopy fraction:1.0 respectFlipped:NO hints:nil];
+	NSRect fromRect = NSMakeRect(0, 0, bitmap.size.width, bitmap.size.height);
+	[bitmap drawInRect:rect fromRect:fromRect operation:NSCompositeCopy fraction:1.0 respectFlipped:NO hints:nil];
 	[ctx flushGraphics];
 	[NSGraphicsContext restoreGraphicsState];
 
@@ -719,19 +720,19 @@
 	CGFloat pixelThreshold = [mergedProperties[@"pixelThreshold"] doubleValue];
 	NSSize maxSize = NSZeroSize;
 	if ([mergedProperties[@"maxSizeMatchesReference"] boolValue]) {
-		maxSize = reference.size;
+		maxSize = NSMakeSize(reference.pixelsWide, reference.pixelsHigh);
 	} else {
 		maxSize = NSMakeSize([mergedProperties[@"maxWidth"] doubleValue], [mergedProperties[@"maxHeight"] doubleValue]);
 	}
 
-	NSSize imageSize = image.size;
+	NSSize imageSize = NSMakeSize(image.pixelsWide, image.pixelsHigh);
 	if ((imageSize.width > maxSize.width) || (imageSize.height > maxSize.height))
 	{
 		NSLog(@"image looks a bit big: %@", NSStringFromSize(imageSize));
 		return NO;
 	}
 
-	NSSize referenceSize = reference.size;
+	NSSize referenceSize = NSMakeSize(reference.pixelsWide, reference.pixelsHigh);
 	if ((referenceSize.width > maxSize.width) || (referenceSize.height > maxSize.height))
 	{
 		NSLog(@"reference looks a bit big: %@", NSStringFromSize(referenceSize));


### PR DESCRIPTION
Code review for Make all rendering comparison tests work with artboards (#10473):

> The recent work on #7150 has laid the foundation for this.
> 
> We have a number of unit tests - not just in SketchRendering - which render pages from documents as pngs and compare the results with reference pngs.
> 
> The idea behind #7150 was supposed to be that we changed _all_ of them over to using artboards instead - not that we simply added a new test taking that approach.

Connect to BohemianCoding/Sketch#10473.
