### PR TITLE
Code Review: Improve build time when nothing has changed (#12237)

### DIFF
--- a/Extras/Scripts/update-version.sh
+++ b/Extras/Scripts/update-version.sh
@@ -15,14 +15,13 @@
 ##
 
 PLIST="$1"
+SHORT_VERSION="$2"
+
 if [ "$PLIST" == "" ]; then
     PLIST="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
 fi
 
-VERSION=`git log --oneline | wc -l`
 COMMIT=`git rev-parse HEAD`
-
-SHORT_VERSION="$2"
 
 # update the plist in the built app
 
@@ -34,6 +33,8 @@ then
     echo "Commit is unchanged - no need to bump build number."
     exit 0
 fi
+
+VERSION=`git log --oneline | wc -l`
 
 if [[ "$EXISTING_COMMIT" == "" ]]
 then


### PR DESCRIPTION
Code review for Improve build time when nothing has changed (#12237):

> Hitting build/run for a second time, after changing nothing, currently results in a substantial delay.
> 
> This is mostly due to script phases running.
> 
> There are three ways to solve or reduce this problem:
> - eliminate the script phases
> - teach Xcode the files that they depend on, so that it knows when it doesn't need to run them
> - speed them up
> 
> In our case I've done some timing, and the phase that's taking longest is the resigning of embedded binaries when building Sketch itself. This used to be optimised not to resign things more than once, but it looks like that might have been broken.
> 
> There is also a resource-copying script in Sketch, which it might now be possible to replace this with a `Copy Resources` phase, since we no longer have an app-store variant and so don't need to do different things for different variants. It takes less than a second to run though, so it's not a priority. It's also not trivial to get the sketchtool stuff to copy into exactly the right places without using a script.
> 
> The other candidate which seems to take some time (just based on watching Xcode's progress display) is in the Quicklook build process. I haven't investigated that any further at this point.
> 
> I should look into all of these to see what I can do to speed up or eliminate them.


Connect to BohemianCoding/Sketch#12237.