### PR TITLE
Code Review: Fix Xcode 10.2 localization warnings (24128)

### DIFF
--- a/ECLogging.xcodeproj/project.pbxproj
+++ b/ECLogging.xcodeproj/project.pbxproj
@@ -670,15 +670,10 @@
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "ECLogging" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				en,
-				ec,
 				Base,
 			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* ECFoundation */;


### PR DESCRIPTION
> fix deprecated languages #24128

connects to https://github.com/BohemianCoding/Sketch/issues/24128
